### PR TITLE
Add lang and dir attributes for English/Arabic

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="%lang%" dir="%dir%">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,0 +1,8 @@
+/** @type {import('@sveltejs/kit').Handle} */
+export function handle({ event, resolve }) {
+  const lang = event.url.pathname.startsWith('/ar') ? 'ar' : 'en';
+  const dir = event.url.pathname.startsWith('/ar') ? 'rtl' : 'ltr';
+	return resolve(event, {
+		transformPageChunk: ({ html }) => html.replace('%lang%', lang).replace('%dir%', dir)
+	});
+}

--- a/src/routes/[lang]/+page.svelte
+++ b/src/routes/[lang]/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import '../../app.css';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { goto, onNavigate } from '$app/navigation';
 	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 	import { domain, texts } from '$lib/data/config';
@@ -18,6 +18,14 @@
 		lo = data.min;
 		hi = data.max;
 	});
+
+	onNavigate(async (event, resolve) => {
+		const lang = event.to.url.pathname.startsWith('/ar') ? 'ar' : 'en';
+		const dir = event.to.url.pathname.startsWith('/ar') ? 'rtl' : 'ltr';
+		document.documentElement.setAttribute('lang', lang);
+		document.documentElement.setAttribute('dir', dir);
+		return resolve;
+	})
 
 	let lo;
 	let hi;
@@ -178,6 +186,8 @@
 			>
 			{#key lang}<button
 					title={t('language')}
+					lang={lang === 'en' ? 'ar' : 'en'}
+					dir={lang === 'en' ? 'rtl' : 'ltr'}
 					on:click={() => goto(`${base}/${lang === 'en' ? 'ar' : 'en'}.html`)}
 					use:tooltip><span>{lang === 'en' ? 'ع' : 'en'}</span></button
 				>{/key}


### PR DESCRIPTION
This PR adds the `dir` attribute for left-to-right/right-to-left languages to the root `<html>` element and updates the `lang` attribute when the user switches languages. It also adds these attributes the language switcher button. This ensures that assistive technology, like a screen reader, will read it out correctly.

I'm new to Svelte so there may be a better way to do this.

(ps - I created the https://wehaddreams.com project. I'd love to collaborate on this or future projects with you. My email is in the commit log.)